### PR TITLE
Fix deprecation warnings on julia 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-#  - release
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4-
+julia 0.5

--- a/src/array.jl
+++ b/src/array.jl
@@ -10,19 +10,19 @@ type IntArray{w,T<:Unsigned,n} <: AbstractArray{T,n}
 end
 
 # call this function when creating an array
-function call{w,T,n}(::Type{IntArray{w,T}}, dims::NTuple{n,Int}, mmap::Bool=false)
+function (::Type{IntArray{w,T}}){w,T,n}(dims::NTuple{n,Int}, mmap::Bool=false)
     return IntArray{w,T,n}(Buffer{w,T}(prod(dims), mmap), dims)
 end
 
-function call{w,T}(::Type{IntArray{w,T}}, len::Integer, mmap::Bool=false)
+function (::Type{IntArray{w,T}}){w,T}(len::Integer, mmap::Bool=false)
     return IntArray{w,T}((len,), mmap)
 end
 
-function call{w,T}(::Type{IntArray{w,T}}, I::Integer...)
+function (::Type{IntArray{w,T}}){w,T}(I::Integer...)
     return IntArray{w,T}(I)
 end
 
-function call{w,T,n}(::Type{IntArray{w,T,n}}, dims::NTuple{n,Int}, mmap::Bool=false)
+function (::Type{IntArray{w,T,n}}){w,T,n}(dims::NTuple{n,Int}, mmap::Bool=false)
     return IntArray{w,T}(dims, mmap)
 end
 

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -1,10 +1,10 @@
 typealias IntMatrix{w,T} IntArray{w,T,2}
 
-function call{w,T}(::Type{IntMatrix{w,T}}, m::Integer, n::Integer, mmap::Bool=false)
+function (::Type{IntMatrix{w,T}}){w,T}(m::Integer, n::Integer, mmap::Bool=false)
     return IntArray{w,T}((m, n), mmap)
 end
 
-function call{w,T}(::Type{IntMatrix{w,T}}, mmap::Bool=false)
+function (::Type{IntMatrix{w,T}}){w,T}(mmap::Bool=false)
     return IntArray{w,T}((0, 0), mmap)
 end
 

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -1,10 +1,10 @@
 typealias IntVector{w,T} IntArray{w,T,1}
 
-function call{w,T}(::Type{IntVector{w,T}}, len::Integer, mmap::Bool=false)
+function (::Type{IntVector{w,T}}){w,T}(len::Integer, mmap::Bool=false)
     return IntArray{w,T}((len,), mmap)
 end
 
-function call{w,T}(::Type{IntVector{w,T}}, mmap::Bool=false)
+function (::Type{IntVector{w,T}}){w,T}(mmap::Bool=false)
     return IntArray{w,T}((0,), mmap)
 end
 


### PR DESCRIPTION
This is necessary for the code to run at all on julia 0.6 (though there are still warnings there).

This also drops support for julia 0.4, which is no longer supported by the latest Compat.jl.