### PR TITLE
Drop Julia v0.6 and support v0.7 and v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,11 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
   - nightly
 matrix:
   allow_failures:
     - julia: nightly
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("IntArrays"); Pkg.test("IntArrays"; coverage=true)'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6
+julia 0.7

--- a/src/IntArrays.jl
+++ b/src/IntArrays.jl
@@ -2,6 +2,8 @@ __precompile__()
 
 module IntArrays
 
+using Mmap
+
 export
     IntArray,
     IntVector,

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -1,13 +1,17 @@
 const IntMatrix{w,T} = IntArray{w,T,2}
 
-function (::Type{IntMatrix{w,T}}){w,T}(m::Integer, n::Integer, mmap::Bool=false)
+function IntMatrix{w,T}(m::Integer, n::Integer, mmap::Bool=false) where {w,T}
     return IntArray{w,T}((m, n), mmap)
 end
 
-function (::Type{IntMatrix{w,T}}){w,T}(mmap::Bool=false)
+function IntMatrix{w,T}(mmap::Bool=false) where {w,T}
     return IntArray{w,T}((0, 0), mmap)
 end
 
-function convert{w,T}(::Type{IntMatrix{w}}, matrix::AbstractMatrix{T})
+function IntMatrix{w}(matrix::AbstractMatrix{T}) where {w,T}
+    return IntArray{w,T,2}(matrix)
+end
+
+function convert(::Type{IntMatrix{w}}, matrix::AbstractMatrix{T}) where {w,T}
     return convert(IntArray{w,T,2}, matrix)
 end

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -1,14 +1,18 @@
 const IntVector{w,T} = IntArray{w,T,1}
 
-function (::Type{IntVector{w,T}}){w,T}(len::Integer, mmap::Bool=false)
+function IntVector{w,T}(len::Integer, mmap::Bool=false) where {w,T}
     return IntArray{w,T}((len,), mmap)
 end
 
-function (::Type{IntVector{w,T}}){w,T}(mmap::Bool=false)
+function IntVector{w,T}(mmap::Bool=false) where {w,T}
     return IntArray{w,T}((0,), mmap)
 end
 
-function convert{w,T}(::Type{IntVector{w}}, vector::AbstractVector{T})
+function IntVector{w}(vector::AbstractVector{T}) where {w,T}
+    return IntArray{w,T,1}(vector)
+end
+
+function convert(::Type{IntVector{w}}, vector::AbstractVector{T}) where {w,T}
     return convert(IntArray{w,T,1}, vector)
 end
 
@@ -33,13 +37,13 @@ end
 function append!(vec::IntVector, items::AbstractVector)
     len = length(vec)
     resize!(vec, len + length(items))
-    for i in 1:endof(items)
+    for i in 1:lastindex(items)
         vec[len+i] = items[i]
     end
     return vec
 end
 
-function reverse!(vec::IntVector, lo::Integer=1, hi::Integer=endof(vec))
+function reverse!(vec::IntVector, lo::Integer=1, hi::Integer=lastindex(vec))
     return reverse!(vec, Int(lo), Int(hi))
 end
 
@@ -55,11 +59,11 @@ end
 
 radixsort(vector::IntVector) = radixsort!(copy(vector))
 
-function radixsort!{w}(vector::IntVector{w})
+function radixsort!(vector::IntVector{w}) where {w}
     return radixsort!(vector, 1, length(vector), w)
 end
 
-function radixsort!{w,T}(v::IntVector{w,T}, lo, hi, k)
+function radixsort!(v::IntVector{w,T}, lo, hi, k) where {w,T}
     @assert 1 ≤ k ≤ w
     if lo > hi
         return v

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using IntArrays
-using Base.Test
+using Test
+using Random
 
-srand(12345)
+Random.seed!(12345)
 
 const Ts = (UInt8, UInt16, UInt32, UInt64)
 
@@ -287,11 +288,11 @@ end
 @testset "conversion" begin
     @testset "empty" begin
         for T in Ts, w in 1:sizeof(T)*8
-            data = Vector{T}(0)
+            data = Vector{T}(undef, 0)
             @test typeof(IntArray{w}(data)) == IntArray{w,T,1}
             @test length(IntArray{w}(data)) == 0
 
-            data = Matrix{T}(0, 0)
+            data = Matrix{T}(undef, 0, 0)
             @test typeof(IntArray{w}(data)) == IntArray{w,T,2}
             @test size(IntArray{w}(data)) == (0, 0)
         end


### PR DESCRIPTION
With this PR, the tests all pass without deprecation warnings on Julia v0.7. There might be one or two `convert()` methods that are no longer necessary, but I think this is pretty good. 